### PR TITLE
feat(basic): 添加基本HTML组件模块

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lyco",
-	"version": "1.3.0",
+	"version": "1.3.5",
 	"description": "Lit-based pure layout rendering function library , including Row/Column/Flex/Grid and other commonly used rendering functions .",
 	"scripts": {
 		"build": "vite build",
@@ -38,6 +38,18 @@
 	"main": "dist/index.cjs.js",
 	"module": "dist/index.es.js",
 	"types": "dist/types/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/types/index.d.ts",
+			"import": "./dist/index.es.js",
+			"require": "./dist/index.cjs.js"
+		},
+		"./basic": {
+			"types": "./dist/types/basic.d.ts",
+			"import": "./dist/basic.es.js",
+			"require": "./dist/basic.cjs.js"
+		}
+	},
 	"files": [
 		"dist",
 		"README.md",

--- a/src/basic.ts
+++ b/src/basic.ts
@@ -1,0 +1,1 @@
+export * from "./components/Basic/mod";

--- a/src/components/AbsoluteBox.ts
+++ b/src/components/AbsoluteBox.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnOrCurry,
 	renderFnType,
-} from "./core";
+} from "../core";
 
 type AbsoluteBoxProps = {
 	top?: string;

--- a/src/components/AcrylicBar.ts
+++ b/src/components/AcrylicBar.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArrayOrCurry,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 interface AcrylicBarProps {
 	width?: string; // 宽度，如 "300px" 或 "50%"

--- a/src/components/AspectRatio.ts
+++ b/src/components/AspectRatio.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 interface AspectRatioProps {
 	ratio: number; // 宽高比，例如 16/9、4/3

--- a/src/components/AutoFitGrid.ts
+++ b/src/components/AutoFitGrid.ts
@@ -9,7 +9,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export function AutoFitGrid(props: {
 	minItemWidth: string;

--- a/src/components/AvatarStack.ts
+++ b/src/components/AvatarStack.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 export function AvatarStack(props?: {
 	size?: string;

--- a/src/components/Badge.ts
+++ b/src/components/Badge.ts
@@ -7,7 +7,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 interface BadgeProps {
 	content?: string | number;

--- a/src/components/Basic/mod.ts
+++ b/src/components/Basic/mod.ts
@@ -1,0 +1,724 @@
+import { html, render, type TemplateResult } from "lit";
+import { StyleInfo, styleMap } from "lit/directives/style-map.js";
+import {
+	createEventBinder,
+	OnEvent,
+	renderFnOrArray,
+	renderFnOrArrayOrCurry,
+	renderFnOrArrayType,
+} from "../../core";
+
+type HTMLEl =
+	| HTMLElementTagNameMap
+	| HTMLElementDeprecatedTagNameMap
+	| SVGElementTagNameMap
+	| MathMLElementTagNameMap;
+
+type Style = string | Readonly<StyleInfo>;
+
+function createStyle(style: Style) {
+	if (typeof style === "string") {
+		return style;
+	} else {
+		return styleMap(style).toString();
+	}
+}
+
+styleMap;
+export type BasicHtmlProps<_T extends keyof HTMLElementTagNameMap, AddPorps> = {
+	className?: string;
+	id?: string;
+	key?: string | number;
+	style?: Style;
+	on?: OnEvent;
+	title?: string;
+	hidden?: boolean;
+	draggable?: boolean;
+	lang?: string;
+	dir?: string;
+	accessKey?: string;
+	tabIndex?: number;
+	contentEditable?: boolean;
+	spellcheck?: boolean;
+	dataset?: DOMStringMap;
+	role?: string;
+	ariaLabel?: string;
+	ariaDescribedBy?: string;
+	ariaHidden?: string;
+	injectFields?: (ref: HTMLElementTagNameMap[_T]) => void;
+} & AddPorps;
+
+export type BasicSVGProps<_T extends keyof SVGElementTagNameMap, AddPorps> = {
+	className?: string;
+	key?: string | number;
+	id?: string;
+	style?: Style;
+	on?: OnEvent;
+	// SVG 特有属性
+	fill?: string;
+	stroke?: string;
+	strokeWidth?: number;
+	viewBox?: string;
+	// 通用SVG属性
+	transform?: string;
+	opacity?: number;
+
+	// 插入字段
+	injectFields?: (ref: SVGElementTagNameMap[_T]) => void;
+} & AddPorps;
+
+export type BasicMathMLProps<
+	_T extends keyof MathMLElementTagNameMap,
+	AddPorps
+> = {
+	className?: string;
+	key?: string | number;
+	id?: string;
+	style?: Style;
+	on?: OnEvent;
+	// MathML 特有属性
+	display?: "block" | "inline";
+	mathbackground?: string;
+	mathcolor?: string;
+	// 插入字段
+	injectFields?: (ref: MathMLElementTagNameMap[_T]) => void;
+} & AddPorps;
+
+export type Props<_T extends keyof HTMLEl, AddPorps> =
+	| BasicHtmlProps<_T, AddPorps>
+	| BasicSVGProps<_T, AddPorps>
+	| BasicMathMLProps<_T, AddPorps>;
+
+type ElementFunction<
+	_T extends keyof _F,
+	_F extends HTMLEl,
+	_P extends Props<_T extends keyof HTMLEl ? _T : never, AddPorps>,
+	AddPorps
+> = {
+	(props?: _P): (
+		children?: renderFnOrArrayType | string | number
+	) => TemplateResult<1>;
+	(
+		props?: _P,
+		children?: renderFnOrArrayType | string | number
+	): TemplateResult<1>;
+};
+
+// 创建一个HTML元素渲染函数工厂
+function createElementRenderer<K extends keyof HTMLElementTagNameMap, Add>(
+	tag: K,
+	addPropsType?: Set<keyof Add>
+) {
+	return (props?: BasicHtmlProps<K, Add>, content?: unknown) => {
+		const _props = (props ?? {}) as BasicHtmlProps<K, Add>;
+		const element = document.createElement(tag);
+		const binder = createEventBinder(_props?.on ?? {});
+		const injectFields = props?.injectFields ?? ((ref) => {});
+		const add = addPropsType ?? new Set();
+		// 应用所有属性
+		_props.className && (element.className = _props.className);
+		_props.id && (element.id = _props.id);
+		_props.style && (element.style.cssText = createStyle(_props.style));
+		_props.title && (element.title = _props.title);
+		_props.lang && (element.lang = _props.lang);
+		_props.dir && (element.dir = _props.dir);
+		_props.role && (element.role = _props.role);
+		_props.ariaLabel && (element.ariaLabel = _props.ariaLabel);
+		_props.ariaHidden && (element.ariaHidden = _props.ariaHidden);
+		_props.key && element.setAttribute("data-key", _props.key.toString());
+		add.forEach((key) => {
+			if (_props[key]) {
+				(element as any)[key] = _props[key];
+			}
+		});
+
+		// 设置布尔属性
+		if (_props.hidden !== undefined) element.hidden = _props.hidden;
+		if (_props.draggable !== undefined) element.draggable = _props.draggable;
+		if (_props.contentEditable !== undefined)
+			element.contentEditable = _props.contentEditable.toString();
+		if (_props.spellcheck !== undefined) element.spellcheck = _props.spellcheck;
+		if (_props.tabIndex !== undefined) element.tabIndex = _props.tabIndex;
+
+		// 设置dataset
+		_props.dataset &&
+			Object.entries(_props.dataset).forEach(([key, value]) => {
+				element.dataset[key] = value;
+			});
+
+		// 绑定事件
+		binder.bind(element);
+		injectFields(element);
+
+		// 处理内容
+		if (
+			content !== null &&
+			typeof content === "object" &&
+			"_$litType$" in content
+		) {
+			// 渲染Lit模板
+			render(content as TemplateResult<1>, element);
+		} else {
+			// 设置文本内容
+			element.textContent = `${content ?? ""}`;
+		}
+
+		// 创建一个包装节点，用于管理生命周期
+		const wrapper = document.createElement("div");
+		wrapper.remove = () => {
+			wrapper.remove();
+			binder.unbindAll();
+		};
+		wrapper.appendChild(element);
+
+		return html`${wrapper.firstElementChild as HTMLElement}`;
+	};
+}
+
+function createMathMLElementRenderer<
+	K extends keyof MathMLElementTagNameMap,
+	Add
+>(tag: K, addPropsType?: Set<keyof Add>) {
+	return (_props?: BasicMathMLProps<K, Add>, content?: unknown) => {
+		const props = _props ?? ({} as BasicMathMLProps<K, Add>);
+		const element = document.createElementNS(
+			"http://www.w3.org/1998/Math/MathML",
+			tag
+		);
+		const binder = createEventBinder(props.on ?? {});
+		const injectFields = props?.injectFields ?? ((ref) => {});
+		const add = addPropsType ?? new Set();
+		// 应用属性
+		props.className && (element.className = props.className);
+		props.id && (element.id = props.id);
+		props.style && (element.style.cssText = createStyle(props.style));
+		props.display && element.setAttribute("display", props.display);
+		props.key && element.setAttribute("data-key", props.key.toString());
+		props.mathbackground &&
+			element.setAttribute("mathbackground", props.mathbackground);
+		props.mathcolor && element.setAttribute("mathcolor", props.mathcolor);
+		add.forEach((key) => {
+			if (props[key]) {
+				(element as any)[key] = props[key];
+			}
+		});
+
+		// 绑定事件和注入字段
+		binder.bind(element);
+		injectFields(element);
+
+		// 处理内容
+		if (
+			content !== null &&
+			typeof content === "object" &&
+			"_$litType$" in content
+		) {
+			render(content as TemplateResult<1>, element as HTMLElement);
+		} else {
+			element.textContent = `${content ?? ""}`;
+		}
+
+		const wrapper = document.createElement("div");
+		wrapper.remove = () => {
+			wrapper.remove();
+			binder.unbindAll();
+		};
+		wrapper.appendChild(element);
+
+		return html`${wrapper.firstElementChild as MathMLElement}`;
+	};
+}
+
+function createSVGElementRenderer<K extends keyof SVGElementTagNameMap, Add>(
+	tag: K,
+	addPropsType?: Set<keyof Add>
+) {
+	return (_props?: BasicSVGProps<K, Add>, content?: unknown) => {
+		const props = _props ?? ({} as BasicSVGProps<K, Add>);
+		const element = document.createElementNS("http://www.w3.org/2000/svg", tag);
+		const binder = createEventBinder(props.on ?? {});
+		const injectFields = props?.injectFields ?? ((ref) => {});
+		const add = addPropsType ?? new Set();
+
+		// 应用SVG属性
+		props.className && element.setAttribute("class", props.className);
+		props.id && (element.id = props.id);
+		props.style && (element.style.cssText = createStyle(props.style));
+		props.fill && element.setAttribute("fill", props.fill);
+		props.stroke && element.setAttribute("stroke", props.stroke);
+		props.key && element.setAttribute("data-key", props.key.toString());
+		props.strokeWidth &&
+			element.setAttribute("stroke-width", props.strokeWidth.toString());
+		props.viewBox && element.setAttribute("viewBox", props.viewBox);
+		props.transform && element.setAttribute("transform", props.transform);
+		props.opacity !== undefined &&
+			element.setAttribute("opacity", props.opacity.toString());
+		add.forEach((key) => {
+			if (props[key]) {
+				const value = props[key];
+				if (typeof value === "function") {
+					(element as any)[key] = value;
+				} else {
+					// 将驼峰式属性名转换为短横线式
+					const attributeName = key
+						.toString()
+						.replace(/([A-Z])/g, "-$1")
+						.toLowerCase();
+					element.setAttribute(attributeName, value.toString());
+				}
+			}
+		});
+
+		// 绑定事件
+		binder.bind(element);
+		injectFields(element);
+
+		// 处理内容
+		if (
+			(content !== null &&
+				typeof content === "object" &&
+				"_$litType$" in content) ||
+			(Array.isArray(content) &&
+				content.length > 0 &&
+				typeof content[0] === "object" &&
+				"_$litType$" in content[0])
+		) {
+			render(content as TemplateResult<1>, element as unknown as HTMLElement);
+		} else {
+			console.log("content", content);
+			element.textContent = `${content ?? ""}`;
+		}
+
+		const wrapper = document.createElement("div");
+		wrapper.remove = () => {
+			wrapper.remove();
+			binder.unbindAll();
+		};
+		wrapper.appendChild(element);
+
+		return html`${wrapper.firstElementChild as SVGElement}`;
+	};
+}
+
+// 元素注册函数
+function registerHtmlElement<K extends keyof HTMLElementTagNameMap, Add>(
+	tag: K,
+	addPropsType?: Set<keyof Add>
+): ElementFunction<K, HTMLElementTagNameMap, BasicHtmlProps<K, Add>, Add> {
+	const renderer = createElementRenderer(tag, addPropsType);
+	return ((props?: BasicHtmlProps<K, Add>, children?: renderFnOrArrayType) => {
+		const render = (c?: renderFnOrArrayType) =>
+			renderer(props, renderFnOrArray(c));
+		return renderFnOrArrayOrCurry(children, render) as
+			| TemplateResult<1>
+			| ((children?: renderFnOrArrayType) => TemplateResult<1>);
+	}) as ElementFunction<K, HTMLElementTagNameMap, BasicHtmlProps<K, Add>, Add>;
+}
+
+function registerMathMLElement<
+	K extends keyof MathMLElementTagNameMap,
+	Add = {}
+>(
+	tag: K,
+	addPropsType?: Set<keyof Add>
+): ElementFunction<K, MathMLElementTagNameMap, BasicMathMLProps<K, Add>, Add> {
+	const renderer = createMathMLElementRenderer(tag, addPropsType);
+	return ((
+		props?: BasicMathMLProps<K, Add>,
+		children?: renderFnOrArrayType
+	) => {
+		const render = (c?: renderFnOrArrayType) =>
+			renderer(props, renderFnOrArray(c));
+		return renderFnOrArrayOrCurry(children, render) as
+			| TemplateResult<1>
+			| ((children?: renderFnOrArrayType) => TemplateResult<1>);
+	}) as ElementFunction<
+		K,
+		MathMLElementTagNameMap,
+		BasicMathMLProps<K, Add>,
+		Add
+	>;
+}
+
+function registerSVGElement<K extends keyof SVGElementTagNameMap, Add>(
+	tag: K,
+	addPropsType?: Set<keyof Add>
+): ElementFunction<K, SVGElementTagNameMap, BasicSVGProps<K, Add>, Add> {
+	const renderer = createSVGElementRenderer(tag, addPropsType);
+	return ((props?: BasicSVGProps<K, Add>, children?: renderFnOrArrayType) => {
+		const render = (c?: renderFnOrArrayType) =>
+			renderer(props, renderFnOrArray(c));
+		return renderFnOrArrayOrCurry(children, render) as
+			| TemplateResult<1>
+			| ((children?: renderFnOrArrayType) => TemplateResult<1>);
+	}) as ElementFunction<K, SVGElementTagNameMap, BasicSVGProps<K, Add>, Add>;
+}
+
+// 定义所有HTML元素映射
+
+type FromAddProps = {
+	method?: string;
+	action?: string;
+	enctype?: string;
+	target?: string;
+	novalidate?: boolean;
+};
+type InputAddProps = {
+	type?: string;
+	value?: string;
+	placeholder?: string;
+	maxLength?: number;
+	minLength?: number;
+	required?: boolean;
+	disabled?: boolean;
+	readonly?: boolean;
+	checked?: boolean;
+	name?: string;
+};
+
+type TextareaAddProps = {
+	rows?: number;
+	cols?: number;
+	wrap?: string;
+	maxLength?: number;
+	minLength?: number;
+	required?: boolean;
+	disabled?: boolean;
+	readonly?: boolean;
+	name?: string;
+};
+
+type SelectAddProps = {
+	multiple?: boolean;
+	required?: boolean;
+	disabled?: boolean;
+	name?: string;
+	size?: number;
+};
+
+type AAddProps = {
+	href?: string;
+	target?: string;
+	rel?: string;
+	download?: string;
+	type?: string;
+};
+
+type ImgAddProps = {
+	src?: string;
+	alt?: string;
+	width?: number | string;
+	height?: number | string;
+	loading?: "lazy" | "eager";
+	decoding?: "sync" | "async" | "auto";
+};
+
+export const htmlElements = {
+	div: registerHtmlElement("div"),
+	p: registerHtmlElement("p"),
+	span: registerHtmlElement("span"),
+	h1: registerHtmlElement("h1"),
+	h2: registerHtmlElement("h2"),
+	h3: registerHtmlElement("h3"),
+	h4: registerHtmlElement("h4"),
+	h5: registerHtmlElement("h5"),
+	h6: registerHtmlElement("h6"),
+	article: registerHtmlElement("article"),
+	section: registerHtmlElement("section"),
+	nav: registerHtmlElement("nav"),
+	aside: registerHtmlElement("aside"),
+	header: registerHtmlElement("header"),
+	footer: registerHtmlElement("footer"),
+	main: registerHtmlElement("main"),
+	ul: registerHtmlElement("ul"),
+	ol: registerHtmlElement("ol"),
+	li: registerHtmlElement("li"),
+	dl: registerHtmlElement("dl"),
+	dt: registerHtmlElement("dt"),
+	dd: registerHtmlElement("dd"),
+	form: registerHtmlElement<"form", FromAddProps>(
+		"form",
+		new Set(["method", "action", "enctype", "target", "novalidate"])
+	),
+	label: registerHtmlElement("label"),
+	input: registerHtmlElement<"input", InputAddProps>("input"),
+	textarea: registerHtmlElement<"textarea", TextareaAddProps>(
+		"textarea",
+		new Set([
+			"cols",
+			"rows",
+			"wrap",
+			"maxLength",
+			"minLength",
+			"required",
+			"disabled",
+			"readonly",
+			"name",
+		])
+	),
+	button: registerHtmlElement("button"),
+	select: registerHtmlElement<"select", SelectAddProps>(
+		"select",
+		new Set(["multiple", "required", "disabled", "name", "size"])
+	),
+	option: registerHtmlElement("option"),
+	table: registerHtmlElement("table"),
+	thead: registerHtmlElement("thead"),
+	tbody: registerHtmlElement("tbody"),
+	tfoot: registerHtmlElement("tfoot"),
+	tr: registerHtmlElement("tr"),
+	th: registerHtmlElement("th"),
+	td: registerHtmlElement("td"),
+	a: registerHtmlElement<"a", AAddProps>(
+		"a",
+		new Set(["href", "target", "rel", "download", "type"])
+	),
+	img: registerHtmlElement<"img", ImgAddProps>(
+		"img",
+		new Set(["src", "alt", "width", "height", "loading", "decoding"])
+	),
+	iframe: registerHtmlElement("iframe"),
+	embed: registerHtmlElement("embed"),
+	object: registerHtmlElement("object"),
+	video: registerHtmlElement("video"),
+	audio: registerHtmlElement("audio"),
+	source: registerHtmlElement("source"),
+	track: registerHtmlElement("track"),
+	canvas: registerHtmlElement("canvas"),
+	map: registerHtmlElement("map"),
+	area: registerHtmlElement("area"),
+	summary: registerHtmlElement("summary"),
+	details: registerHtmlElement("details"),
+	slot: registerHtmlElement("slot"),
+	template: registerHtmlElement("template"),
+	style: registerHtmlElement("style"),
+	script: registerHtmlElement("script"),
+	link: registerHtmlElement("link"),
+	meta: registerHtmlElement("meta"),
+	title: registerHtmlElement("title"),
+	base: registerHtmlElement("base"),
+	head: registerHtmlElement("head"),
+	body: registerHtmlElement("body"),
+	html: registerHtmlElement("html"),
+	abbr: registerHtmlElement("abbr"),
+	b: registerHtmlElement("b"),
+	bdi: registerHtmlElement("bdi"),
+	bdo: registerHtmlElement("bdo"),
+	blockquote: registerHtmlElement("blockquote"),
+	br: registerHtmlElement("br"),
+	caption: registerHtmlElement("caption"),
+	cite: registerHtmlElement("cite"),
+	code: registerHtmlElement("code"),
+	col: registerHtmlElement("col"),
+	colgroup: registerHtmlElement("colgroup"),
+	data: registerHtmlElement("data"),
+	del: registerHtmlElement("del"),
+	dfn: registerHtmlElement("dfn"),
+	em: registerHtmlElement("em"),
+	i: registerHtmlElement("i"),
+	kbd: registerHtmlElement("kbd"),
+	mark: registerHtmlElement("mark"),
+	q: registerHtmlElement("q"),
+	rp: registerHtmlElement("rp"),
+	rt: registerHtmlElement("rt"),
+	ruby: registerHtmlElement("ruby"),
+	s: registerHtmlElement("s"),
+	samp: registerHtmlElement("samp"),
+	small: registerHtmlElement("small"),
+	strong: registerHtmlElement("strong"),
+	sub: registerHtmlElement("sub"),
+	sup: registerHtmlElement("sup"),
+	time: registerHtmlElement("time"),
+	u: registerHtmlElement("u"),
+	var: registerHtmlElement("var"),
+	address: registerHtmlElement("address"),
+	progress: registerHtmlElement("progress"),
+	meter: registerHtmlElement("meter"),
+	output: registerHtmlElement("output"),
+	datalist: registerHtmlElement("datalist"),
+	dialog: registerHtmlElement("dialog"),
+	menu: registerHtmlElement("menu"),
+	fieldset: registerHtmlElement("fieldset"),
+	legend: registerHtmlElement("legend"),
+	figcaption: registerHtmlElement("figcaption"),
+	figure: registerHtmlElement("figure"),
+	hgroup: registerHtmlElement("hgroup"),
+	hr: registerHtmlElement("hr"),
+	ins: registerHtmlElement("ins"),
+	noscript: registerHtmlElement("noscript"),
+	optgroup: registerHtmlElement("optgroup"),
+	picture: registerHtmlElement("picture"),
+	pre: registerHtmlElement("pre"),
+	search: registerHtmlElement("search"),
+	wbr: registerHtmlElement("wbr"),
+} as const;
+
+export const mathmlElements = {
+	math: registerMathMLElement("math"),
+	mstyle: registerMathMLElement("mstyle"),
+	merror: registerMathMLElement("merror"),
+	mtext: registerMathMLElement("mtext"),
+	mspace: registerMathMLElement("mspace"),
+	msqrt: registerMathMLElement("msqrt"),
+	mroot: registerMathMLElement("mroot"),
+	mrow: registerMathMLElement("mrow"),
+	mfrac: registerMathMLElement("mfrac"),
+	msup: registerMathMLElement("msup"),
+	msub: registerMathMLElement("msub"),
+	msubsup: registerMathMLElement("msubsup"),
+	munder: registerMathMLElement("munder"),
+	mover: registerMathMLElement("mover"),
+	munderover: registerMathMLElement("munderover"),
+	mmultiscripts: registerMathMLElement("mmultiscripts"),
+	mtable: registerMathMLElement("mtable"),
+	mtr: registerMathMLElement("mtr"),
+	mtd: registerMathMLElement("mtd"),
+	ms: registerMathMLElement("ms"),
+	mphantom: registerMathMLElement("mphantom"),
+	annotation: registerMathMLElement("annotation"),
+	"annotation-xml": registerMathMLElement("annotation-xml"),
+	mprescripts: registerMathMLElement("mprescripts"),
+	maction: registerMathMLElement("maction"),
+	mi: registerMathMLElement("mi"),
+	mn: registerMathMLElement("mn"),
+	mo: registerMathMLElement("mo"),
+	mpadded: registerMathMLElement("mpadded"),
+	semantics: registerMathMLElement("semantics"),
+};
+
+type SvgAddProps = {
+	width?: number | string;
+	height?: number | string;
+	xmlns?: string;
+	version?: string;
+};
+
+type CircleAddProps = {
+	cx?: number | string;
+	cy?: number | string;
+	r?: number | string;
+};
+
+type PathAddProps = {
+	d?: string;
+	pathLength?: number;
+};
+
+type RectAddProps = {
+	x?: number | string;
+	y?: number | string;
+	width?: number | string;
+	height?: number | string;
+	rx?: number | string;
+	ry?: number | string;
+};
+
+type TextAddProps = {
+	x?: number | string;
+	y?: number | string;
+	fontSize?: number | string;
+	textAnchor?: "start" | "middle" | "end" | "inherit";
+	fontWeight?: "normal" | "bold" | "bolder" | "lighter" | "inherit";
+};
+
+export const svgElements = {
+	svg: registerSVGElement<"svg", SvgAddProps>(
+		"svg",
+		new Set(["width", "height", "xmlns", "version"])
+	),
+	defs: registerSVGElement("defs"),
+	desc: registerSVGElement("desc"),
+	title: registerSVGElement("title"),
+	metadata: registerSVGElement("metadata"),
+	g: registerSVGElement("g"),
+	a: registerSVGElement("a"),
+	circle: registerSVGElement<"circle", CircleAddProps>(
+		"circle",
+		new Set(["cx", "cy", "r"])
+	),
+	ellipse: registerSVGElement("ellipse"),
+	line: registerSVGElement("line"),
+	path: registerSVGElement<"path", PathAddProps>(
+		"path",
+		new Set(["d", "pathLength"])
+	),
+	polygon: registerSVGElement("polygon"),
+	polyline: registerSVGElement("polyline"),
+	rect: registerSVGElement<"rect", RectAddProps>(
+		"rect",
+		new Set(["x", "y", "width", "height", "rx", "ry"])
+	),
+	use: registerSVGElement("use"),
+	stop: registerSVGElement("stop"),
+	tspan: registerSVGElement("tspan"),
+	text: registerSVGElement<"text", TextAddProps>(
+		"text",
+		new Set(["x", "y", "fontSize", "textAnchor", "fontWeight"])
+	),
+	image: registerSVGElement("image"),
+	clipPath: registerSVGElement("clipPath"),
+	linearGradient: registerSVGElement("linearGradient"),
+	radialGradient: registerSVGElement("radialGradient"),
+	mask: registerSVGElement("mask"),
+	pattern: registerSVGElement("pattern"),
+	marker: registerSVGElement("marker"),
+	symbol: registerSVGElement("symbol"),
+	view: registerSVGElement("view"),
+	animateMotion: registerSVGElement("animateMotion"),
+	animateTransform: registerSVGElement("animateTransform"),
+	filter: registerSVGElement("filter"),
+	style: registerSVGElement("style"),
+	script: registerSVGElement("script"),
+	animate: registerSVGElement("animate"),
+	set: registerSVGElement("set"),
+	mpath: registerSVGElement("mpath"),
+	foreignObject: registerSVGElement("foreignObject"),
+	textPath: registerSVGElement("textPath"),
+	feBlend: registerSVGElement("feBlend"),
+	feColorMatrix: registerSVGElement("feColorMatrix"),
+	feComponentTransfer: registerSVGElement("feComponentTransfer"),
+	feComposite: registerSVGElement("feComposite"),
+	feConvolveMatrix: registerSVGElement("feConvolveMatrix"),
+	feDiffuseLighting: registerSVGElement("feDiffuseLighting"),
+	feDisplacementMap: registerSVGElement("feDisplacementMap"),
+	feFlood: registerSVGElement("feFlood"),
+	feGaussianBlur: registerSVGElement("feGaussianBlur"),
+	feImage: registerSVGElement("feImage"),
+	feMerge: registerSVGElement("feMerge"),
+	feMorphology: registerSVGElement("feMorphology"),
+	feOffset: registerSVGElement("feOffset"),
+	feSpecularLighting: registerSVGElement("feSpecularLighting"),
+	feTile: registerSVGElement("feTile"),
+	feTurbulence: registerSVGElement("feTurbulence"),
+	feDistantLight: registerSVGElement("feDistantLight"),
+	fePointLight: registerSVGElement("fePointLight"),
+	feSpotLight: registerSVGElement("feSpotLight"),
+	feFuncR: registerSVGElement("feFuncR"),
+	feFuncG: registerSVGElement("feFuncG"),
+	feFuncB: registerSVGElement("feFuncB"),
+	feFuncA: registerSVGElement("feFuncA"),
+	feDropShadow: registerSVGElement("feDropShadow"),
+	feMergeNode: registerSVGElement("feMergeNode"),
+	switch: registerSVGElement("switch"),
+};
+
+/**
+ * @alias elements
+ */
+export const $El = htmlElements;
+
+/**
+ * @alias mathmlElements
+ */
+export const $MathEl = mathmlElements;
+
+/**
+ * @alias svgElements
+ */
+export const $SvgEl = svgElements;
+
+export const $AllEl = {
+	...htmlElements,
+	...mathmlElements,
+	...svgElements,
+};

--- a/src/components/Canvas.ts
+++ b/src/components/Canvas.ts
@@ -1,6 +1,6 @@
 import { html, TemplateResult } from "lit";
 import { createRef, ref, RefOrCallback } from "lit/directives/ref.js";
-import { createEventBinder, OnEvent } from "./core";
+import { createEventBinder, OnEvent } from "../core";
 
 // 合并两个 ref 的辅助函数
 function combineRefs<T>(

--- a/src/components/Card.ts
+++ b/src/components/Card.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 interface CardProps {
 	padding?: string;

--- a/src/components/Center.ts
+++ b/src/components/Center.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 export function Center(props?: {
 	width?: string;
 	height?: string;

--- a/src/components/Column.ts
+++ b/src/components/Column.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 export function Column(props?: {
 	space?: string | number;

--- a/src/components/ColumnSplit.ts
+++ b/src/components/ColumnSplit.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export function ColumnSplit(props?: {
 	firstHeight?: string; // 第一个面板固定高度或百分比

--- a/src/components/Combobox.ts
+++ b/src/components/Combobox.ts
@@ -1,13 +1,13 @@
 import { html, TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
-import { MD3 } from "../theme/md3";
 import {
 	createEventBinder,
 	getComponentCount,
 	getRandomClassName,
 	LycoComponent,
 	OnEvent,
-} from "./core";
+} from "../core";
+import { MD3 } from "../theme/md3";
 
 export interface ComboboxOption {
 	value: string;

--- a/src/components/Container.ts
+++ b/src/components/Container.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 export type ContainerProps = {
 	maxWidth?: string;

--- a/src/components/Dialog/Dialog.ts
+++ b/src/components/Dialog/Dialog.ts
@@ -9,7 +9,7 @@ import {
 	renderFnOrArray,
 	renderFnOrArrayOrCurry,
 	renderFnOrArrayType,
-} from "../core";
+} from "../../core";
 import { MD3 } from "../../theme/md3";
 
 export enum DialogPlacement {

--- a/src/components/Dialog/DialogActions.ts
+++ b/src/components/Dialog/DialogActions.ts
@@ -6,7 +6,7 @@ import {
 	renderFnOrArray,
 	renderFnOrArrayOrCurry,
 	renderFnOrArrayType,
-} from "../core";
+} from "../../core";
 
 type DialogActionsProps = {
 	className?: string;

--- a/src/components/Dialog/DialogButton.ts
+++ b/src/components/Dialog/DialogButton.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnOrCurry,
 	renderFnType,
-} from "../core";
+} from "../../core";
 
 type DialogButtonProps = {
 	variant?: "text" | "contained";

--- a/src/components/Dialog/DialogContent.ts
+++ b/src/components/Dialog/DialogContent.ts
@@ -5,7 +5,7 @@ import {
 	renderFnOrArray,
 	renderFnOrArrayOrCurry,
 	renderFnOrArrayType,
-} from "../core";
+} from "../../core";
 
 type DialogContentProps = {
 	className?: string;

--- a/src/components/Dialog/DialogTitle.ts
+++ b/src/components/Dialog/DialogTitle.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnOrCurry,
 	renderFnType,
-} from "../core";
+} from "../../core";
 
 type DialogTitleProps = {
 	className?: string;

--- a/src/components/Divider.ts
+++ b/src/components/Divider.ts
@@ -1,6 +1,6 @@
 import { html } from "lit";
 import { ref } from "lit/directives/ref.js";
-import { createEventBinder, OnEvent } from "./core";
+import { createEventBinder, OnEvent } from "../core";
 
 export function Divider(props?: {
 	orientation?: "horizontal" | "vertical";

--- a/src/components/Flex.ts
+++ b/src/components/Flex.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 interface FlexProps {
 	direction?: "row" | "column";

--- a/src/components/FlowItem.ts
+++ b/src/components/FlowItem.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export function FlowItem(props?: { on?: OnEvent }): WithHtml<renderFnType>;
 export function FlowItem(

--- a/src/components/FooterLayout.ts
+++ b/src/components/FooterLayout.ts
@@ -7,7 +7,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 interface FooterLayoutProps {
 	columns?: number;

--- a/src/components/Grid.ts
+++ b/src/components/Grid.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 export function Grid(props?: {
 	columns?: number;

--- a/src/components/GridBreakpoint.ts
+++ b/src/components/GridBreakpoint.ts
@@ -9,7 +9,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export type GridBreakpointProps = {
 	breakpoints: Record<string, number>;

--- a/src/components/GridCol.ts
+++ b/src/components/GridCol.ts
@@ -9,7 +9,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export function GridCol(props?: {
 	gap?: string | number;

--- a/src/components/GridItem.ts
+++ b/src/components/GridItem.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export function GridItem(props?: {
 	span?: number;

--- a/src/components/GridRow.ts
+++ b/src/components/GridRow.ts
@@ -9,7 +9,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export function GridRow(props?: {
 	gap?: string | number;

--- a/src/components/HeroSection.ts
+++ b/src/components/HeroSection.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 export function HeroSection(props?: {
 	backgroundImage?: string;

--- a/src/components/Hidden.ts
+++ b/src/components/Hidden.ts
@@ -10,7 +10,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export type HiddenProps = {
 	breakpoint?: string;

--- a/src/components/LightboxContainer.ts
+++ b/src/components/LightboxContainer.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export function LightboxContainer(props?: {
 	fadeBg?: string;

--- a/src/components/List.ts
+++ b/src/components/List.ts
@@ -6,7 +6,7 @@ import {
 	LycoComponent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 // ListItem 组件
 export function ListItem(children?: renderFnOrArrayType): TemplateResult<1> {

--- a/src/components/ListGroup.ts
+++ b/src/components/ListGroup.ts
@@ -9,7 +9,7 @@ import {
 	renderFnOrArray,
 	renderFnOrArrayOrCurry,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 export function ListGroup(props?: {
 	bordered?: boolean;

--- a/src/components/Overlay.ts
+++ b/src/components/Overlay.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 export function Overlay(props?: {
 	background?: string;

--- a/src/components/PositionContainer.ts
+++ b/src/components/PositionContainer.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export function PositionContainer(props?: {
 	width?: string;

--- a/src/components/Progress.ts
+++ b/src/components/Progress.ts
@@ -1,6 +1,6 @@
 import { css, html, TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
-import { createEventBinder, OnEvent } from "./core";
+import { createEventBinder, OnEvent } from "../core";
 
 type ProgressProps = {
 	value?: number; // 主进度 (0-100)

--- a/src/components/Row.ts
+++ b/src/components/Row.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 export function Row(props?: {
 	space?: string | number;

--- a/src/components/RowSplit.ts
+++ b/src/components/RowSplit.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export function RowSplit(props?: {
 	firstWidth?: string; // 第一个面板固定宽度或百分比

--- a/src/components/ScrollBar.ts
+++ b/src/components/ScrollBar.ts
@@ -9,7 +9,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export function ScrollBar(props?: {
 	direction?: "vertical" | "horizontal";

--- a/src/components/SideBarContainer.ts
+++ b/src/components/SideBarContainer.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 export function SideBarContainer(props?: {
 	sidebarWidth?: string; // 侧边栏宽度，比如 "240px"

--- a/src/components/SizedBox.ts
+++ b/src/components/SizedBox.ts
@@ -1,6 +1,6 @@
 import { html } from "lit";
 import { ref } from "lit/directives/ref.js";
-import { createEventBinder, OnEvent } from "./core";
+import { createEventBinder, OnEvent } from "../core";
 
 export function SizedBox(props?: {
 	width?: string;

--- a/src/components/SkeletonLoader.ts
+++ b/src/components/SkeletonLoader.ts
@@ -7,7 +7,7 @@ import {
 	getRandomClassName,
 	LycoComponent,
 	OnEvent,
-} from "./core";
+} from "../core";
 
 export function SkeletonLoader(props?: {
 	type?: "rect" | "circle";

--- a/src/components/Spacer.ts
+++ b/src/components/Spacer.ts
@@ -1,6 +1,6 @@
 import { html } from "lit";
 import { ref } from "lit/directives/ref.js";
-import { createEventBinder, OnEvent } from "./core";
+import { createEventBinder, OnEvent } from "../core";
 
 export function Spacer(props?: { on?: OnEvent }) {
 	const binder = createEventBinder(props?.on ?? {});

--- a/src/components/Spinner.ts
+++ b/src/components/Spinner.ts
@@ -5,7 +5,7 @@ import {
 	getComponentCount,
 	LycoComponent,
 	OnEvent,
-} from "./core";
+} from "../core";
 import { MD3 } from "../theme/md3";
 
 type SpinnerProps = {

--- a/src/components/Sticky.ts
+++ b/src/components/Sticky.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 interface StickyProps {
 	top?: string;

--- a/src/components/Swiper.ts
+++ b/src/components/Swiper.ts
@@ -6,7 +6,7 @@ import {
 	getRandomClassName,
 	LycoComponent,
 	OnEvent,
-} from "./core";
+} from "../core";
 
 type ScrollDirection = "x" | "y" | "both";
 type ScrollBehavior = "auto" | "smooth";

--- a/src/components/SwitchInput.ts
+++ b/src/components/SwitchInput.ts
@@ -1,13 +1,13 @@
 import { html, TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
-import { MD3 } from "../theme/md3";
 import {
 	createEventBinder,
 	getComponentCount,
 	getRandomClassName,
 	LycoComponent,
 	OnEvent,
-} from "./core";
+} from "../core";
+import { MD3 } from "../theme/md3";
 
 export interface SwitchInputProps {
 	checked?: boolean;

--- a/src/components/Table.ts
+++ b/src/components/Table.ts
@@ -9,7 +9,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 import { MD3 } from "../theme/md3";
 
 export interface TableProps {

--- a/src/components/Tooltip.ts
+++ b/src/components/Tooltip.ts
@@ -6,7 +6,7 @@ import {
 	renderFn,
 	renderFnOrCurry,
 	renderFnType,
-} from "./core";
+} from "../core";
 
 export enum WithTooltipPlacement {
 	Top = "top",

--- a/src/components/WaterFlow.ts
+++ b/src/components/WaterFlow.ts
@@ -9,7 +9,7 @@ import {
 	renderFn,
 	renderFnType,
 	WithHtml,
-} from "./core";
+} from "../core";
 
 export interface WaterFlowProps {
 	columnCount?: number;

--- a/src/components/Wrap.ts
+++ b/src/components/Wrap.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 interface WrapProps {
 	direction?: "row" | "column";

--- a/src/components/ZStack.ts
+++ b/src/components/ZStack.ts
@@ -5,7 +5,7 @@ import {
 	OnEvent,
 	renderFnOrArray,
 	renderFnOrArrayType,
-} from "./core";
+} from "../core";
 
 interface ZStackProps {
 	width?: string;

--- a/src/components/mod.ts
+++ b/src/components/mod.ts
@@ -1,3 +1,5 @@
+import { renderFnOrArray, renderFnOrArrayType } from "../core";
+
 export {
 	Virtualizer,
 	VirtualizerController,
@@ -58,3 +60,7 @@ export { Spinner } from "./Spinner";
 export { WithTooltip } from "./Tooltip";
 // 弹窗组件
 export * from "./Dialog";
+
+export function $Html(slot: renderFnOrArrayType) {
+	return renderFnOrArray(slot);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./components";
+export * from "./components/mod";

--- a/stories/Dialog.stories.ts
+++ b/stories/Dialog.stories.ts
@@ -2,12 +2,13 @@ import { Meta, StoryFn } from "@storybook/web-components";
 import { html } from "lit";
 import { createRef } from "lit/directives/ref.js";
 import {
+	$Html,
 	Dialog,
 	DialogActions,
 	DialogButton,
 	DialogContent,
 	DialogTitle,
-} from "../src/components";
+} from "../src/components/mod";
 
 const Template: StoryFn = (args) => {
 	const handleClose = () => {
@@ -45,29 +46,30 @@ const Template: StoryFn = (args) => {
 	`;
 };
 
-export const WithComplexContent = () => html`
-	${Dialog({ open: true }, [
-		DialogTitle({}, () => html`复杂内容示例`),
-		DialogContent({}, [
-			html`<h3>表单示例</h3>`,
-			html`<div style="margin: 16px 0;">
-				<label>用户名: </label>
-				<input type="text" />
-			</div>`,
-			html`<div style="margin: 16px 0;">
-				<label>密码: </label>
-				<input type="password" />
-			</div>`,
-		]),
-		DialogActions({}, [
-			DialogButton({}, () => html`取消`),
-			DialogButton(
-				{ variant: "contained", color: "primary" },
-				() => html`提交`
-			),
-		]),
-	])}
-`;
+export const WithComplexContent = () =>
+	$Html(
+		Dialog({ open: true }, [
+			DialogTitle({}, () => html`复杂内容示例`),
+			DialogContent({}, [
+				html`<h3>表单示例</h3>`,
+				html`<div style="margin: 16px 0;">
+					<label>用户名: </label>
+					<input type="text" />
+				</div>`,
+				html`<div style="margin: 16px 0;">
+					<label>密码: </label>
+					<input type="password" />
+				</div>`,
+			]),
+			DialogActions({}, [
+				DialogButton({}, () => html`取消`),
+				DialogButton(
+					{ variant: "contained", color: "primary" },
+					() => html`提交`
+				),
+			]),
+		])
+	);
 
 export const MultipleButtons = () => html`
 	${Dialog({ open: true }, [
@@ -85,8 +87,8 @@ export const CustomStyles = () => {
 	let isOpened = true;
 	const dRef = createRef<HTMLDialogElement>();
 	const rRef = createRef<HTMLDivElement>();
-	return html`
-		${Dialog({
+	return $Html(
+		Dialog({
 			open: isOpened,
 			proxyRef: dRef,
 			movable: rRef,
@@ -114,8 +116,8 @@ export const CustomStyles = () => {
 					variant: "contained",
 				})(html`确定`),
 			]),
-		])}
-	`;
+		])
+	);
 };
 
 const meta = {

--- a/stories/Spinner.stories.ts
+++ b/stories/Spinner.stories.ts
@@ -1,9 +1,11 @@
 import { Meta } from "@storybook/web-components";
 import { html } from "lit";
-import { Progress, Row, Spinner, WithTooltip } from "../src/components";
+import { $El } from "../src/basic";
 import { Combobox } from "../src/components/Combobox";
+import { Progress, Row, Spinner, WithTooltip } from "../src/components/mod";
 import { SwitchInput } from "../src/components/SwitchInput";
 import { WithTooltipPlacement } from "../src/components/Tooltip";
+import { DashboardComponent } from "./Svg";
 
 export default {
 	title: "Example/Spinner",
@@ -155,6 +157,15 @@ export const StrokeDasharray = () => html`
 		${Spinner({ svgMode: true, strokeDasharray: "", size: "32px" })}
 		${Spinner({ svgMode: true, strokeDasharray: "5,5", size: "32px" })}
 		${Spinner({ svgMode: true, strokeDasharray: "10,5,2,5", size: "32px" })}
+		${$El.div({
+			style: "width: 32px; height: 32px;",
+			on: {
+				click() {
+					console.log("clicked");
+				},
+			},
+		})("123")}
+		${DashboardComponent()}
 		<!-- ${Progress({
 			value: 40,
 			bufferValue: 70,

--- a/stories/Svg.ts
+++ b/stories/Svg.ts
@@ -1,0 +1,194 @@
+import { html, TemplateResult } from "lit";
+import { $Html } from "../src";
+import { $AllEl } from "../src/basic";
+
+// 模拟数据源
+interface ChartData {
+	id: number;
+	label: string;
+	value: number;
+	color: string;
+}
+
+const data: ChartData[] = [
+	{ id: 1, label: "A", value: 30, color: "#FF6B6B" },
+	{ id: 2, label: "B", value: 50, color: "#4ECDC4" },
+	{ id: 3, label: "C", value: 70, color: "#45B7D1" },
+	{ id: 4, label: "D", value: 40, color: "#96CEB4" },
+];
+
+// 状态模拟：高亮显示某个数据项
+let highlightedId: number | null = null;
+
+// 点击事件处理函数
+const handleClick = (item: ChartData) => {
+	highlightedId = highlightedId === item.id ? null : item.id;
+};
+
+// 构建条形图
+const renderBarChart = (): TemplateResult => {
+	const barWidth = 30;
+	const spacing = 10;
+	const maxValue = Math.max(...data.map((d) => d.value));
+	const chartHeight = 200; // 增加高度
+	const chartWidth = (barWidth + spacing) * data.length + spacing; // 计算总宽度
+
+	return $Html(
+		$AllEl.div(
+			{
+				style: {
+					width: `${chartWidth}px`,
+					height: `${chartHeight}px`,
+					margin: "20px",
+				},
+			},
+			$AllEl.svg(
+				{
+					width: "100%",
+					height: "100%",
+					style: {
+						backgroundColor: "#f8f8f8",
+					},
+					viewBox: `0 0 ${chartWidth} ${chartHeight}`,
+					on: {
+						click: () => {
+							highlightedId = null;
+						},
+					},
+				},
+				[
+					...data.map((item, index) => {
+						const x = spacing + index * (barWidth + spacing);
+						const barHeight = (item.value / maxValue) * (chartHeight - 40); // 留出上下边距
+						const y = chartHeight - barHeight - 20; // 底部留出边距
+
+						return $AllEl.g(
+							{
+								key: item.id,
+								transform: `translate(${x}, 0)`,
+								on: {
+									click: (e: Event) => {
+										e.stopPropagation();
+										handleClick(item);
+									},
+								},
+								style: {
+									cursor: "pointer",
+									transition: "transform 0.3s ease",
+								},
+							},
+							[
+								// 条形柱
+								$AllEl.rect({
+									x: 0,
+									y: y,
+									width: barWidth,
+									height: barHeight,
+									fill: item.color,
+									stroke: highlightedId === item.id ? "black" : "none",
+									strokeWidth: 2,
+								})(),
+
+								// 标签
+								$AllEl.text({
+									x: barWidth / 2,
+									y: y - 5,
+									fontSize: 12,
+									textAnchor: "middle",
+									fill: "black",
+								})(item.label),
+
+								// 值
+								$AllEl.text({
+									x: barWidth / 2,
+									y: chartHeight - 5,
+									fontSize: 12,
+									textAnchor: "middle",
+									fill: "gray",
+								})(`${item.value}`),
+							]
+						);
+					}),
+				]
+			)
+		)
+	) as TemplateResult<1>;
+};
+
+// 构建饼图扇区路径
+const renderPieSlice = (
+	startAngle: number,
+	endAngle: number,
+	radius: number,
+	color: string
+): TemplateResult<1> => {
+	const largeArcFlag = endAngle - startAngle > 180 ? 1 : 0;
+	const x1 = radius + radius * Math.cos((startAngle * Math.PI) / 180);
+	const y1 = radius + radius * Math.sin((startAngle * Math.PI) / 180);
+	const x2 = radius + radius * Math.cos((endAngle * Math.PI) / 180);
+	const y2 = radius + radius * Math.sin((endAngle * Math.PI) / 180);
+
+	const pathData = `
+    M ${radius},${radius}
+    L ${x1},${y1}
+    A ${radius},${radius} 0 ${largeArcFlag},1 ${x2},${y2}
+    Z
+  `;
+
+	return $AllEl.path({
+		d: pathData.trim(),
+		fill: color,
+		stroke: "white",
+		strokeWidth: 1,
+	})();
+};
+
+// 构建饼图
+const renderPieChart = (): TemplateResult => {
+	const radius = 50;
+	let currentAngle = 0;
+
+	return $Html(
+		$AllEl.svg(
+			{
+				width: "100%",
+				height: "100%",
+				viewBox: `0 0 ${radius * 2} ${radius * 2}`,
+				style: "background-color: #f8f8f8",
+			},
+			[
+				...data.map((item) => {
+					const sliceAngle = (item.value / 200) * 360; // 总值为 200
+					const nextAngle = currentAngle + sliceAngle;
+					const result = renderPieSlice(
+						currentAngle,
+						nextAngle,
+						radius,
+						item.color
+					);
+					currentAngle = nextAngle;
+					return result;
+				}),
+				// 中心文字
+				$AllEl.text({
+					x: radius,
+					y: radius + 5,
+					fontSize: 12,
+					textAnchor: "middle",
+					fontWeight: "bold",
+					fill: "black",
+				})("Sales"),
+			]
+		)
+	) as TemplateResult<1>;
+};
+
+// 组合图表组件
+export const DashboardComponent = () => {
+	return html`
+		<div style="display: flex; gap: 20px; padding: 20px;">
+			<div>${renderBarChart()}</div>
+			<div>${renderPieChart()}</div>
+		</div>
+	`;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,9 +9,12 @@ export default defineConfig({
 	build: {
 		// 指定库模式构建
 		lib: {
-			entry: path.resolve(__dirname, "src/index.ts"),
+			entry: {
+				index: path.resolve(__dirname, "src/index.ts"),
+				basic: path.resolve(__dirname, "src/basic.ts"),
+			},
 			name: "Lyco", // UMD 名称（如果需要 UMD 格式，可额外配置）
-			fileName: (format) => `index.${format}.js`,
+			fileName: (format, entryName) => `${entryName}.${format}.js`,
 			formats: ["es", "cjs"], // 仅输出 ESM + CJS
 		},
 		rollupOptions: {
@@ -22,6 +25,7 @@ export default defineConfig({
 				"lit/directives/ref.js",
 				"lit/directives/unsafe-svg.js",
 				"lit/directives/style-map.js",
+				"lit/directives/unsafe-html.js",
 			],
 			output: {
 				// 为每种格式添加注释 banner（可选）
@@ -34,6 +38,8 @@ export default defineConfig({
 		// vite-plugin-dts 用于生成类型声明文件到 dist/types
 		dts({
 			insertTypesEntry: true, // 在 dist 根目录生成 index.d.ts
+			// 忽略 stories 目录
+			exclude: ["stories"],
 			outDir: "dist/types",
 			tsconfigPath: "tsconfig.json",
 		}),


### PR DESCRIPTION
新增`basic.ts`文件，包含HTML、SVG和MathML元素的渲染函数。调整了多个组件文件中的核心模块导入路径，从相对路径改为绝对路径。更新了`index.ts`文件，导出新的`basic.ts`模块。修改了`vite.config.ts`，配置了多个入口文件，并更新了rollupOptions中的external配置。

- 新增`basic.ts`文件，包含HTML、SVG和MathML元素的渲染函数。
- 调整了`AbsoluteBox.ts`、`AcrylicBar.ts`、`AspectRatio.ts`、`AutoFitGrid.ts`、`AvatarStack.ts`、`Badge.ts`、`Canvas.ts`、`Card.ts`、`Center.ts`、`Column.ts`、`ColumnSplit.ts`、`Combobox.ts`、`Container.ts`、`Divider.ts`、`Flex.ts`、`FlowItem.ts`、`FooterLayout.ts`、`Grid.ts`、`GridBreakpoint.ts`、`GridCol.ts`、`GridItem.ts`、`GridRow.ts`、`HeroSection.ts`、`Hidden.ts`、`LightboxContainer.ts`、`List.ts`、`ListGroup.ts`、`Overlay.ts`、`PositionContainer.ts`、`Progress.ts`、`Row.ts`、`RowSplit.ts`、`ScrollBar.ts`、`SideBarContainer.ts`、`SizedBox.ts`、`SkeletonLoader.ts`、`Spacer.ts`、`Spinner.ts`、`Sticky.ts`、`Swiper.ts`、`SwitchInput.ts`、`Table.ts`、`Tooltip.ts`、`WaterFlow.ts`、`Wrap.ts`、`ZStack.ts`中的核心模块导入路径，从相对路径改为绝对路径。
- 更新了`Dialog.ts`、`DialogActions.ts`、`DialogButton.ts`、`DialogContent.ts`、`DialogTitle.ts`中的核心模块导入路径，从相对路径改为绝对路径。
- 修改了`index.ts`文件，导出新的`basic.ts`模块。
- 修改了`vite.config.ts`，配置了多个入口文件，并更新了rollupOptions中的external配置。
- 新增`Svg.ts`测试文件，包含SVG条形图和饼图的示例。